### PR TITLE
Allow configuring log output.

### DIFF
--- a/log.go
+++ b/log.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"time"
+	"io"
 )
 
 var defaultLogger = New("", 3)
@@ -64,6 +65,14 @@ func New(prefix string, depth int) *Logger {
 
 	l.SetPrefix(prefix)
 	return l
+}
+
+func (this *Logger) SetAllOutput(w io.Writer) {
+	this.info.SetOutput(w)
+	this.warning.SetOutput(w)
+	this.error.SetOutput(w)
+	this.slack.SetOutput(w)
+	this.request.SetOutput(w)
 }
 
 func (this *Logger) ErrLogger() *log.Logger {


### PR DESCRIPTION
We communicate with the AWS Lambda shim using stdout.

We need a way to configure logging so it doesn't go to stdout.

Another option I could do is to just export all the loggers (info, warning, error, slack, request) so the could be directly modified from a different package.